### PR TITLE
remove uneccesary slash

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@ title: Jekyll PWA Starter
 timezone: UTC
 destination: _site/
 domainname: https://pwa-jekyll-starter.netlify.com
-baseurl: /
+baseurl: ''
 sitename: My Website
 assetsurl: /static-assets/
 markdown: kramdown


### PR DESCRIPTION
a simple single quote eliminates the issue of having an extra trailing slash on the root url when building locally.